### PR TITLE
https prevents an X-Forwarded-For bug with proxy

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -25,7 +25,7 @@ var serverHTTPReqTopic string
 func main() {
 
 	// Get our server address and ports
-	rsp, err := http.Get("http://checkip.amazonaws.com")
+	rsp, err := http.Get("https://checkip.amazonaws.com")
 	if err != nil {
 		fmt.Printf("can't get our own IP address: %s", err)
 		return


### PR DESCRIPTION
There are times checkip.amazonaws.com will actually return multiple ip addresses. If using http and a proxy server adds an x-forwarded-for header that's one case. The https should make that less likely.